### PR TITLE
29 latest docker image broken binsh yamlfixer permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM python:3.11.0a3-alpine
 LABEL maintainer="michele.barre@opt.nc, jerome.alet@opt.nc, adrien.sales@opt.nc"
 
+
+RUN pip install --upgrade pip
+
+RUN adduser -D worker
+USER worker
+
 RUN pip install yamlfixer-opt-nc
+ENV PATH="/home/worker/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ LABEL maintainer="michele.barre@opt.nc, jerome.alet@opt.nc, adrien.sales@opt.nc"
 
 
 RUN pip install --upgrade pip
-
-RUN adduser -D worker
-USER worker
-
 RUN pip install yamlfixer-opt-nc
+
 ENV PATH="/home/worker/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
 FROM python:3.11.0a3-alpine
-LABEL maintainer="michele.barre@opt.nc, jerome.alet@opt.nc"
+LABEL maintainer="michele.barre@opt.nc, jerome.alet@opt.nc, adrien.sales@opt.nc"
 
-COPY yamlfixer /usr/local/bin/yamlfixer
-COPY requirements.txt /requirements.txt
-
-RUN chmod 0755 /usr/local/bin/yamlfixer
-RUN pip install -r /requirements.txt
+RUN pip install yamlfixer-opt-nc


### PR DESCRIPTION
I could test-run the Dockerfile with no regression for the GH Actions as permissions are working : 

With the current fix, this script can be run successfully on any ubuntu : 

```
git clone https://github.com/opt-nc/yamlfixer.git
cd yamlfixer
git checkout 29-latest-docker-image-broken-binsh-yamlfixer-permission-denied
git status

docker build -t yamlfixer .

docker run -it -v $PWD/examples:/examples --rm yamlfixer /bin/sh

cd examples
ls -la
yamlfixer --summary *.yml
```

cf #29 