### PR TITLE
:lady_beetle:  :snake:  Python 3.6 not supported anymore on Ubuntu 22.04 :older_adult: 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'


### PR DESCRIPTION
cf: 

- https://github.com/opt-nc/yamlfixer/pull/199
- https://github.com/actions/setup-python/issues/561
- https://github.com/actions/setup-python/issues/561#issuecomment-1340657956

Apparemment c'est un bug de [setup-python](https://github.com/actions/setup-python) : 

- https://github.com/actions/setup-python/issues/544