### PR TITLE
Support pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: yamlfixer
+  name: yamlfixer
+  entry: yamlfixer
+  language: python
+  language_version: python3
+  types: [yaml]


### PR DESCRIPTION
Add .pre-commit-hooks for Support pre-commit

Example pre-commit configuration
```yaml
# .pre-commit-config.yaml
repos:
- repo: https://github.com/opt-nc/yamlfixer
  rev: main
  hooks:
  - id: yamlfixer
```