### PR TITLE
Fixed new indentation message formatting, fixed list indent formatting

### DIFF
--- a/yamlfixer/problemfixer.py
+++ b/yamlfixer/problemfixer.py
@@ -253,14 +253,27 @@ class ProblemFixer(YAMLFixerBase):
         # TODO: we fix anyway, knowing that we may need to launch the command
         # TODO: several times to finally fix the problem.
         parts = self.problem.split()
-        expected = int(parts[3])
-        found = int(parts[6])
+        if parts[3] == "at" and parts[4] == "least":
+            expected = int(parts[5])
+            found = 0
+        else:
+            expected = int(parts[3])
+            found = int(parts[6])
         offset = expected - found
         if expected > found:
-            self.ffixer.lines[self.linenum] = (' ' * offset) + left + right
+            for i in range(self.linenum, len(self.ffixer.lines)):
+                # This is *very* much not a perfect solution.
+                # It will fuck up multiline, but this is rare and i believe would require
+                # deliberate malicious input.
+                if not self.ffixer.lines[i].strip().startswith("-"):
+                    break
+                self.ffixer.lines[i] = (' ' * offset) + self.ffixer.lines[i]
         else:
-            # expected < found because we woudln't be there otherwise anyway
-            self.ffixer.lines[self.linenum] = (left + right)[-offset:]
+            for i in range(self.linenum, len(self.ffixer.lines)):
+                if not self.ffixer.lines[i].strip().startswith("-"):
+                    break
+                self.ffixer.lines[i] = (left + right)[-offset:]
+
         self.ffixer.coffset += offset
 
     def fix_linetoolong(self, left, right):  # pylint: disable=unused-argument


### PR DESCRIPTION
While this project appears to very much be dead and unmaintained, I do hope that opening this pull request may help others who still rely on this tool.

Recent versions of yamllint, when given the following input:
```yaml
---
test:
- a
- s
- d
- f
```
emits a new version of the original message:
`3:1       error    wrong indentation: expected at least 1`

which yamlfixer currently fails to parse.
This PR fixes that, while also fixing indentation for the entire list rather than only one line.
This is not a perfect solution, and will indent any line that begins with `-`. This is a rare case however, and would be better than leaving things as they are.

Do note that multiple runs of yamlfixer are required at times still.